### PR TITLE
Readme update, Vagrantfile update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you don't have them, use the following commands to install them with `homebre
 ```bash
 brew cask install virtualbox
 brew cask install vagrant
-``` 
+```
 
 ### Setup Project and VM
 
@@ -40,7 +40,22 @@ NOTE: It is required to have your ssh agent running or have a copy of your ssh p
 
 ### Setup Vagrant and VirtualBox on Windows
 
-TODO
+Make sure you have Vagrant and VirtualBox installed on your machine. If you don't have them, use the following links to download and install required software:
+
+[VirtualBox for Windows](https://www.virtualbox.org/wiki/Downloads)
+
+[Vagrant for Windows](https://www.vagrantup.com/downloads.html)
+
+Run following commands in PowerShell command line to create a directory for the project, download Vagrantfile and bring up the VM:
+
+```pwsh
+mkdir [project-name]
+cd [project-name]
+$dir = (Get-Location)
+$client = new-object System.Net.WebClient
+$client.DownloadFile("https://raw.githubusercontent.com/rails-on-services/setup/master/Vagrantfile","$dir\Vagrantfile")
+vagrant up
+```
 
 ## Verify VM Configuration
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,10 +59,10 @@ Vagrant.configure('2') do |config|
 
   project_name = Dir.pwd.split('/').last
   # The hostname set for the VM should only contain letters, numbers, hyphens or dots. It cannot start with a hyphen or dot.
-  # Strip any hypens and dots from the begining of the string
-  project_name.gsub!(/^[-.]+/, "")
   # Strip any char that is not letter, number, hyphen or dot
   project_name.gsub!(/[^0-9A-Za-z.-]+/, "")
+  # Strip any hypens and dots from the begining of the string
+  project_name.gsub!(/^[-.]+/, "")
   config.vm.define project_name do |node|
     node.vm.provider :virtualbox do |v|
       v.name = project_name
@@ -82,16 +82,15 @@ Vagrant.configure('2') do |config|
   config.vm.synced_folder '.', '/vagrant', disabled: true
   
   if Vagrant::Util::Platform.windows? then
-	# Windows compatible mount options. Tested on Win 7 SP1
-    config.vm.synced_folder '.', "/home/vagrant/#{project_name}", type: 'nfs',
-    mount_options: ['dmode=775','fmode=775'],
-    linux__nfs_options: ['rw', 'no_subtree_check', 'all_squash', 'async']
+    # Windows compatible mount options. Tested on Win 7 SP1
+    mo = ['dmode=775','fmode=775']
   else
-    config.vm.synced_folder '.', "/home/vagrant/#{project_name}", type: 'nfs',
-    mount_options: ['rw', 'vers=3', 'tcp'],
-    linux__nfs_options: ['rw', 'no_subtree_check', 'all_squash', 'async']
+    mo = ['rw', 'vers=3', 'tcp']
   end
- 
+  config.vm.synced_folder '.', "/home/vagrant/#{project_name}", type: 'nfs',
+  mount_options: mo,
+  linux__nfs_options: ['rw', 'no_subtree_check', 'all_squash', 'async']
+
   config.vm.provision 'build', type: 'shell', privileged: false, inline: <<-SHELL
     sudo apt install git --yes
     git clone https://github.com/rails-on-services/setup.git ~/#{project_name}/ros/setup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,11 +48,21 @@ Vagrant.configure('2') do |config|
       # meminfo returns kilobytes, convert to MB
       # v.memory = rep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'to_i / 1024 / 8
       v.cpus = %x(nproc).to_i
+	elsif host =~ /mswin|mingw|cygwin/
+      # Windows. Tested on Win 7 SP1
+      # 80% of available free memory, 50% of available CPUs
+      v.memory = (`wmic OS get FreePhysicalMemory`.split[1].to_i / 1024 * 0.80).to_i
+	  cpus = `wmic computersystem Get NumberOfLogicalProcessors`.split[1].to_i / 2
+	  cpus < 1 ? v.cpus = 1 : v.cpus = cpus
     end
   end
 
   project_name = Dir.pwd.split('/').last
-
+  # The hostname set for the VM should only contain letters, numbers, hyphens or dots. It cannot start with a hyphen or dot.
+  # Strip any hypens and dots from the begining of the string
+  project_name.gsub!(/^[-.]+/, "")
+  # Strip any char that is not letter, number, hyphen or dot
+  project_name.gsub!(/[^0-9A-Za-z.-]+/, "")
   config.vm.define project_name do |node|
     node.vm.provider :virtualbox do |v|
       v.name = project_name
@@ -70,10 +80,18 @@ Vagrant.configure('2') do |config|
   end
   config.ssh.forward_agent = true
   config.vm.synced_folder '.', '/vagrant', disabled: true
-  config.vm.synced_folder '.', "/home/vagrant/#{project_name}", type: 'nfs',
+  
+  if Vagrant::Util::Platform.windows? then
+	# Windows compatible mount options. Tested on Win 7 SP1
+    config.vm.synced_folder '.', "/home/vagrant/#{project_name}", type: 'nfs',
+    mount_options: ['dmode=775','fmode=775'],
+    linux__nfs_options: ['rw', 'no_subtree_check', 'all_squash', 'async']
+  else
+    config.vm.synced_folder '.', "/home/vagrant/#{project_name}", type: 'nfs',
     mount_options: ['rw', 'vers=3', 'tcp'],
     linux__nfs_options: ['rw', 'no_subtree_check', 'all_squash', 'async']
-
+  end
+ 
   config.vm.provision 'build', type: 'shell', privileged: false, inline: <<-SHELL
     sudo apt install git --yes
     git clone https://github.com/rails-on-services/setup.git ~/#{project_name}/ros/setup


### PR DESCRIPTION
Please review following changes.

1. Readme.md - added section "Setup Vagrant and VirtualBox on Windows"
2. Vagrantfile - Add correct mount options that works with Windows Host OS, add VM CPU/MEM allocation as 80% free memory, 50% of total logical CPUs, add VM hostname sanitizing checks (I caught an error when project directory contained underscore)