### PR TITLE
Temporary workaround. AWSCLI hardcoded version. …

### DIFF
--- a/devops.yml
+++ b/devops.yml
@@ -8,7 +8,9 @@
 
     - name: Install awscli
       pip:
-        name: awscli
+        # Temporary workaround as latest awscli fails to get EKS credentials in our CircleCi environment
+        # https://github.com/kubernetes/kubectl/issues/747
+        name: awscli==1.16.210
         state: present
       become: yes
 


### PR DESCRIPTION
Latest aws-cli(1.16.261) fails to get kubectl token when deploying from Ci.

Tested that version 1.16.210 works just fine on the same Ci instance.